### PR TITLE
feat: Enable autoplay for embedded YouTube video

### DIFF
--- a/frontend/src/components/VideoSection.tsx
+++ b/frontend/src/components/VideoSection.tsx
@@ -69,7 +69,7 @@ const VideoSection = () => {
           <div className="relative w-full" style={{ paddingBottom: '56.25%' /* 16:9 aspect ratio */ }}>
             <iframe
               className="absolute top-0 left-0 w-full h-full rounded-2xl border-2 border-primary/20"
-              src="https://www.youtube.com/embed/pdC6dFg2Yfw"
+              src="https://www.youtube.com/embed/pdC6dFg2Yfw?autoplay=1&mute=1"
               title="YouTube video player"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen


### PR DESCRIPTION
This commit adds the `autoplay=1&mute=1` parameters to the YouTube video embed URL. This will cause the video to autoplay when it becomes visible in the viewport. The video is muted by default to comply with browser autoplay policies.