### PR TITLE
feat: Attempt to enable autoplay with sound for embedded video

### DIFF
--- a/frontend/src/components/VideoSection.tsx
+++ b/frontend/src/components/VideoSection.tsx
@@ -69,7 +69,7 @@ const VideoSection = () => {
           <div className="relative w-full" style={{ paddingBottom: '56.25%' /* 16:9 aspect ratio */ }}>
             <iframe
               className="absolute top-0 left-0 w-full h-full rounded-2xl border-2 border-primary/20"
-              src="https://www.youtube.com/embed/pdC6dFg2Yfw?autoplay=1&mute=1"
+              src="https://www.youtube.com/embed/pdC6dFg2Yfw?autoplay=1"
               title="YouTube video player"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen


### PR DESCRIPTION
This commit removes the `mute=1` parameter from the YouTube embed URL in an attempt to enable autoplay with sound.

As noted in previous communications, this feature is not guaranteed to work across all browsers due to modern browser policies that restrict autoplay with sound to prevent a disruptive user experience. The video quality settings were not changed as there is no supported parameter for forcing a specific resolution.