### PR TITLE
fix: Correct formatting of testimonial roles

### DIFF
--- a/frontend/src/components/TestimonialsSection.tsx
+++ b/frontend/src/components/TestimonialsSection.tsx
@@ -7,7 +7,7 @@ gsap.registerPlugin(ScrollTrigger);
 const testimonials = [
   {
     name: "Client 1",
-    role: "Founder Oliver Smith ( From Canada )",
+    role: "Founder, Oliver Smith (From Canada)",
     company: "",
     quote: "They delivered exactly what we needed—on time and on brand.",
     video_url: "/media/testimonials/client-1.mp4",
@@ -17,7 +17,7 @@ const testimonials = [
   },
   {
     name: "Client 2",
-    role: "Marketing Head Riya Tiwari ( From India )",
+    role: "Marketing Head, Riya Tiwari (From India)",
     company: "",
     quote: "The website performance and design boosted our conversions.",
     video_url: "/media/testimonials/client-2.mp4",
@@ -27,7 +27,7 @@ const testimonials = [
   },
   {
     name: "Client 3",
-    role: "CTO Noah Davis ( From England )",
+    role: "CTO, Noah Davis (From England)",
     company: "",
     quote: "Clean code, clear communication, and great results.",
     video_url: "/media/testimonials/client-3.mp4",
@@ -37,7 +37,7 @@ const testimonials = [
   },
   {
     name: "Client 4",
-    role: "Product Lead Isabella Garcia ( From Canada )",
+    role: "Product Lead, Isabella Garcia (From Canada)",
     company: "",
     quote: "A professional partner who truly understands UX.",
     video_url: "/media/testimonials/client-4.mp4",


### PR DESCRIPTION
Corrects the formatting of the role text in the testimonial cards. This change adds a comma after the role title and removes extra spaces to improve readability, as per the user's request.